### PR TITLE
Bug 1043385 - change output so it conforms to structured logging

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -18,10 +18,10 @@ function SocketReporter(runner) {
   runner.on('pass', this.onPass);
   this.onPending = this.onPending.bind(this);
   runner.on('pending', this.onPending);
-  this.onTest = this.onTest.bind(this);
-  runner.on('test', this.onTest);
-  this.onTestEnd = this.onTestEnd.bind(this);
-  runner.on('test end', this.onTestEnd);
+  this.onSuite = this.onSuite.bind(this);
+  runner.on('suite', this.onSuite);
+  this.onSuiteEnd = this.onSuiteEnd.bind(this);
+  runner.on('suite end', this.onSuiteEnd);
 
   this.status = 'PASS';
   this.result = new corredor.Publisher();
@@ -77,25 +77,30 @@ SocketReporter.prototype = {
   },
 
   /**
-   * @param {Test} test started test.
+   * @param {Suite} started test suite.
    */
-  onTest: function(test) {
-    this.result.send({action: 'test_start',
-                      test: this.getFile(test)});
+  onSuite: function(suite) {
+    // NOTE: root suites have no attached test, file or manifest,
+    // so we treat each test file as a suite
+    if (!suite.root) {
+      this.result.send({action: 'test_start',
+                      test: this.getFile(suite)});
+    }
   },
 
   /**
-   * @param {Test} test finished test.
+   * @param {Suite} finished suite.
    */
-  onTestEnd: function(test) {
-    var data = {action: 'test_end',
-                test: this.getTitle(test),
-                status: this.status};
-    // TODO This assumes the expected is always PASS
-    if (this.status != 'PASS') {
-      data.expected = 'PASS';
+  onSuiteEnd: function(suite) {
+    if (suite.parent && suite.parent.root) {
+      var data = {action: 'test_end',
+                  test: this.getFile(suite),
+                  status: this.status};
+      if (this.status != 'PASS') {
+        data.expected = 'PASS';
+      }
+      this.result.send(data);
     }
-    this.result.send(data);
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-socket-reporter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Andrew Halberstadt <ahalberstadt@mozilla.org>",
   "description": "Mocha reporter for streaming results over a socket",
   "license": "MIT",

--- a/test/socket_test.js
+++ b/test/socket_test.js
@@ -30,8 +30,8 @@ suite('SocketReporter', function() {
     sinon.assert.calledWith(on, 'fail');
     sinon.assert.calledWith(on, 'pass');
     sinon.assert.calledWith(on, 'pending');
-    sinon.assert.calledWith(on, 'test');
-    sinon.assert.calledWith(on, 'test end');
+    sinon.assert.calledWith(on, 'suite');
+    sinon.assert.calledWith(on, 'suite end');
 
     sinon.assert.called(socket);
     assert.strictEqual(subject.status, 'PASS');
@@ -93,30 +93,31 @@ suite('SocketReporter', function() {
                                    'status': subject.status});
   });
 
-  test('#onTest', function() {
+  test('#onSuite', function() {
     var testObj = {
       file: 'doge_start_test_wow.js',
       fullTitle: function() {
         return 'some title';
       }
     };
-    subject.onTest(testObj);
+    subject.onSuite(testObj);
 
     sinon.assert.calledWith(send, {'action': 'test_start',
                                    'test': subject.getFile(testObj)});
   });
 
-  test('#onTestEnd', function() {
+  test('#onSuiteEnd', function() {
     var testObj = {
-      file: 'doge_end_test_wow.js',
-      fullTitle: function() {
-        return 'some title';
+      parent: {
+        root: true,
+        file: 'doge_end_test_wow.js',
+        status: 'PASS'
       }
     };
-    subject.onTestEnd(testObj);
+    subject.onSuiteEnd(testObj);
 
     sinon.assert.calledWith(send, {'action': 'test_end',
-                                   'test': subject.getTitle(testObj),
+                                   'test': subject.getFile(testObj),
                                    'status': subject.status});
   });
 


### PR DESCRIPTION
if (suite.parent && suite.parent.root)  is needed in onSuiteEnd because we catch onSuiteEnd for each subtest. We only want to log TEST-END when all subtests are complete, and that is only when the suite is the parent, ie when parent.root is true
